### PR TITLE
Adding unit tests and test reporting to the dataframe-rules-engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ project/project/
 project/target/
 *.DS_Store
 /target/
-/project/
+/project/build.properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,3 @@
 We happily welcome contributions to *Databricks Labs - dataframe-rules-engine*. 
 We use GitHub Issues to track community reported issues and GitHub Pull Requests for accepting changes.
+Please make a fork of this repository and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ and add it as soon as possible.
 
 Some ideas of great adds are:
 * Add a Python wrapper
+* Enable an external table to host the rules and have rules compiled from externally managed source (GREAT idea from Sri Tikkireddy)
 * Refactor Rule and/or Validator to implement an Abstract class or trait
     * There's a clear opportunity to abstract away some of the redundancy between rule types.
 * Implement a fast runner 

--- a/README.md
+++ b/README.md
@@ -182,3 +182,21 @@ cd Downloads
 git pull repo
 sbt clean package
 ```
+
+## Running tests
+To run tests on the project: <br>
+```
+sbt test
+```
+
+Make sure that your JAVA_HOME is setup for sbt to run the tests properly. You will need JDK 8 as Spark does
+not support newer versions of the JDK.
+
+## Test reports for test coverage
+To get test coverage report for the project: <br>
+```
+sbt jacoco
+```
+
+The test reports can be found in target/scala-<version>/jacoco/
+

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,26 @@ scalacOptions ++= Seq("-Xmax-classfile-name", "78")
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.0"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.1.1"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % "test"
+
+lazy val excludes = jacocoExcludes in Test := Seq()
+
+lazy val jacoco = jacocoReportSettings in test  :=JacocoReportSettings(
+  "Jacoco Scala Example Coverage Report",
+  None,
+  JacocoThresholds (branch = 100),
+  Seq(JacocoReportFormats.ScalaHTML,
+    JacocoReportFormats.CSV),
+  "utf-8")
+
+val jacocoSettings = Seq(jacoco)
+lazy val jse = (project in file (".")).settings(jacocoSettings: _*)
+
+fork in Test := true
+javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD")
+
 
 lazy val commonSettings = Seq(
   version := "0.1",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.3")

--- a/src/main/scala/com/databricks/labs/validation/QuickTest.scala
+++ b/src/main/scala/com/databricks/labs/validation/QuickTest.scala
@@ -1,0 +1,37 @@
+package com.databricks.labs.validation
+
+import com.databricks.labs.validation.utils.Structures.{Bounds, MinMaxRuleDef}
+import com.databricks.labs.validation.utils.SparkSessionWrapper
+import org.apache.spark.sql.functions._
+
+object QuickTest extends App with SparkSessionWrapper {
+
+  import spark.implicits._
+
+  val testDF = Seq(
+    (1, 2, 3),
+    (4, 5, 6),
+    (7, 8, 9)
+  ).toDF("retail_price", "scan_price", "cost")
+
+  Rule("Reasonable_sku_counts", count(col("sku")), Bounds(lower = 20.0, upper = 200.0))
+
+  val minMaxPriceDefs = Array(
+    MinMaxRuleDef("MinMax_Retail_Price_Minus_Scan_Price", col("retail_price")-col("scan_price"), Bounds(0.0, 29.99)),
+    MinMaxRuleDef("MinMax_Scan_Price_Minus_Retail_Price", col("scan_price")-col("retail_price"), Bounds(0.0, 29.99))
+  )
+
+  val someRuleSet = RuleSet(testDF)
+    .add(Rule("retail_pass", col("retail_price"), Bounds(lower = 1.0, upper = 7.0)))
+    .add(Rule("retail_agg_pass_high", max(col("retail_price")), Bounds(lower = 0.0, upper = 7.1)))
+    .add(Rule("retail_agg_pass_low", min(col("retail_price")), Bounds(lower = 0.0, upper = 7.0)))
+    .add(Rule("retail_fail_low", col("retail_price"), Bounds(lower = 1.1, upper = 7.0)))
+    .add(Rule("retail_fail_high", col("retail_price"), Bounds(lower = 0.0, upper = 6.9)))
+    .add(Rule("retail_agg_fail_high", max(col("retail_price")), Bounds(lower = 0.0, upper = 6.9)))
+    .add(Rule("retail_agg_fail_low", min(col("retail_price")), Bounds(lower = 1.1, upper = 7.0)))
+    .addMinMaxRules(minMaxPriceDefs: _*)
+  val (rulesReport, passed) = someRuleSet.validate()
+
+  testDF.show(20, false)
+  rulesReport.show(20, false)
+}

--- a/src/main/scala/com/databricks/labs/validation/Rule.scala
+++ b/src/main/scala/com/databricks/labs/validation/Rule.scala
@@ -20,7 +20,7 @@ class Rule {
   private var _validNumerics: Array[Double] = _
   private var _validStrings: Array[String] = _
   private var _dateTimeLogic: Column = _
-  private var _ruleType: String = _
+  private var _ruleType: RuleType.Value = _
   private var _isAgg: Boolean = _
 
   private def setRuleName(value: String): this.type = {
@@ -69,7 +69,7 @@ class Rule {
     this
   }
 
-  private def setRuleType(value: String): this.type = {
+  private def setRuleType(value: RuleType.Value): this.type = {
     _ruleType = value
     this
   }
@@ -99,7 +99,7 @@ class Rule {
 
   def dateTimeLogic: Column = _dateTimeLogic
 
-  def ruleType: String = _ruleType
+  def ruleType: RuleType.Value = _ruleType
 
   private[validation] def isAgg: Boolean = _isAgg
 
@@ -121,7 +121,7 @@ object Rule {
       .setRuleName(ruleName)
       .setColumn(column)
       .setBoundaries(boundaries)
-      .setRuleType("bounds")
+      .setRuleType(RuleType.ValidateBounds)
       .setIsAgg
   }
 
@@ -135,7 +135,7 @@ object Rule {
       .setRuleName(ruleName)
       .setColumn(column)
       .setValidNumerics(validNumerics)
-      .setRuleType("validNumerics")
+      .setRuleType(RuleType.ValidateNumerics)
       .setIsAgg
   }
 
@@ -149,7 +149,7 @@ object Rule {
       .setRuleName(ruleName)
       .setColumn(column)
       .setValidNumerics(validNumerics.map(_.toString.toDouble))
-      .setRuleType("validNumerics")
+      .setRuleType(RuleType.ValidateNumerics)
       .setIsAgg
   }
 
@@ -163,7 +163,7 @@ object Rule {
       .setRuleName(ruleName)
       .setColumn(column)
       .setValidNumerics(validNumerics.map(_.toString.toDouble))
-      .setRuleType("validNumerics")
+      .setRuleType(RuleType.ValidateNumerics)
       .setIsAgg
   }
 
@@ -177,7 +177,7 @@ object Rule {
       .setRuleName(ruleName)
       .setColumn(column)
       .setValidStrings(validStrings)
-      .setRuleType("validStrings")
+      .setRuleType(RuleType.ValidateStrings)
       .setIsAgg
   }
 

--- a/src/main/scala/com/databricks/labs/validation/RuleType.scala
+++ b/src/main/scala/com/databricks/labs/validation/RuleType.scala
@@ -1,0 +1,12 @@
+package com.databricks.labs.validation
+
+/**
+ * Definition of the Rule Types as an Enumeration for better type matching
+ */
+object RuleType extends Enumeration {
+  val ValidateBounds = Value("bounds")
+  val ValidateNumerics = Value("validNumerics")
+  val ValidateStrings = Value("validStrings")
+  val ValidateDateTime = Value("validDateTime")
+  val ValidateComplex = Value("complex")
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+# Set everything to be logged to the console
+log4j.rootCategory=ERROR, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=WARN
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN
+log4j.logger.org.apache.spark.sql.SparkSession$Builder=ERROR

--- a/src/test/scala/com/databricks/labs/validation/SparkSessionFixture.scala
+++ b/src/test/scala/com/databricks/labs/validation/SparkSessionFixture.scala
@@ -1,0 +1,12 @@
+package com.databricks.labs.validation
+
+import org.apache.spark.sql.SparkSession
+
+trait SparkSessionFixture {
+  lazy val spark = SparkSession
+    .builder()
+    .master("local")
+    .appName("spark session")
+    .config("spark.sql.shuffle.partitions", "1")
+    .getOrCreate()
+}

--- a/src/test/scala/com/databricks/labs/validation/ValidationTestSuite.scala
+++ b/src/test/scala/com/databricks/labs/validation/ValidationTestSuite.scala
@@ -1,0 +1,120 @@
+package com.databricks.labs.validation
+
+import com.databricks.labs.validation.utils.SparkSessionWrapper
+import com.databricks.labs.validation.utils.Structures.{Bounds, MinMaxRuleDef}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+
+class ValidationTestSuite extends org.scalatest.FunSuite with SparkSessionFixture {
+
+  import spark.implicits._
+  spark.sparkContext.setLogLevel("ERROR")
+
+  test("The input dataframe should have no rule failures on MinMaxRule") {
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 9)
+    ).toDF("retail_price", "scan_price", "cost")
+    val minMaxPriceDefs = Array(
+      MinMaxRuleDef("MinMax_Sku_Price", col("retail_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Scan_Price", col("scan_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Cost", col("cost"), Bounds(0.0, 12.0))
+    )
+
+    // Generate the array of Rules from the minmax generator
+
+    val someRuleSet = RuleSet(testDF)
+    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    val (rulesReport, passed) = someRuleSet.validate()
+    assert(passed == true)
+  }
+
+  test("The input dataframe should have exactly 1 rule failure on MinMaxRule") {
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 99)
+    ).toDF("retail_price", "scan_price", "cost")
+    val minMaxPriceDefs = Array(
+      MinMaxRuleDef("MinMax_Sku_Price", col("retail_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Scan_Price", col("scan_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Cost", col("cost"), Bounds(0.0, 12.0))
+    )
+    // Generate the array of Rules from the minmax generator
+
+    val someRuleSet = RuleSet(testDF)
+    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    val (rulesReport, passed) = someRuleSet.validate()
+    val failedResults  = rulesReport.filter(rulesReport("Invalid_Count") > 0).collect()
+    assert(failedResults.length == 1)
+    assert(failedResults(0)(0) == "MinMax_Cost_max")
+    assert(passed == false)
+  }
+
+  test("The DF in the rulesset object is the same as the input test df") {
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 99)
+    ).toDF("retail_price", "scan_price", "cost")
+    val minMaxPriceDefs = Array(
+      MinMaxRuleDef("MinMax_Sku_Price", col("retail_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Scan_Price", col("scan_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Cost", col("cost"), Bounds(0.0, 12.0))
+    )
+    // Generate the array of Rules from the minmax generator
+
+    val someRuleSet = RuleSet(testDF)
+    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    val rulesDf = someRuleSet.getDf
+    assert(testDF.except(rulesDf).count() == 0)
+  }
+
+  test("The group by columns are the correct group by clauses in the validation") {
+    // 2 groups so count of the rules should yield (2 minmax rules * 2 columns) * 2 groups in cost (8 rows)
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 3)
+    ).toDF("retail_price", "scan_price", "cost")
+    val minMaxPriceDefs = Array(
+      MinMaxRuleDef("MinMax_Sku_Price", col("retail_price"), Bounds(0.0, 29.99)),
+      MinMaxRuleDef("MinMax_Scan_Price", col("scan_price"), Bounds(0.0, 29.99))
+    )
+
+    val someRuleSet = RuleSet(testDF, "cost")
+    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    val groupBys = someRuleSet.getGroupBys
+    val (groupByValidated, passed) = someRuleSet.validate()
+
+    assert(groupBys.length == 1)
+    assert(groupBys(0) == "cost")
+    assert(someRuleSet.isGrouped == true)
+    assert(passed == true)
+    assert(groupByValidated.count() == 8)
+    assert(groupByValidated.filter(groupByValidated("Invalid_Count") > 0).count() == 0)
+    assert(groupByValidated.filter(groupByValidated("Failed") === true).count() == 0)
+  }
+
+  test("Validate list of values for numerics.") {
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 99)
+    ).toDF("retail_price", "scan_price", "cost")
+    val rule = Rule("CheckIfCostIsInLOV", col("cost"), Array(3,6,99))
+    // Generate the array of Rules from the minmax generator
+
+    val someRuleSet = RuleSet(testDF)
+    someRuleSet.add(rule)
+    assert(rule.ruleType == RuleType.ValidateNumerics)
+//    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+//    val (rulesReport, passed) = someRuleSet.validate()
+//    val failedResults  = rulesReport.filter(rulesReport("Invalid_Count") > 0).collect()
+//    assert(failedResults.length == 1)
+//    assert(failedResults(0)(0) == "MinMax_Cost_max")
+//    assert(passed == false)
+  }
+
+}

--- a/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
+++ b/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
@@ -5,12 +5,14 @@ import com.databricks.labs.validation.utils.Structures.{Bounds, MinMaxRuleDef}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 
-class ValidationTestSuite extends org.scalatest.FunSuite with SparkSessionFixture {
+class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture {
 
   import spark.implicits._
   spark.sparkContext.setLogLevel("ERROR")
 
   test("The input dataframe should have no rule failures on MinMaxRule") {
+    //  2 per rule so 2 MinMax_Sku_Price + 2 MinMax_Scan_Price + 2 MinMax_Cost + 2 MinMax_Cost_Generated
+    // + 2 MinMax_Cost_manual = 10 rules
     val testDF = Seq(
       (1, 2, 3),
       (4, 5, 6),
@@ -23,11 +25,16 @@ class ValidationTestSuite extends org.scalatest.FunSuite with SparkSessionFixtur
     )
 
     // Generate the array of Rules from the minmax generator
+    val rulesArray = RuleSet.generateMinMaxRules(MinMaxRuleDef("MinMax_Cost_Generated", col("cost"), Bounds(0.0, 12.0)))
 
     val someRuleSet = RuleSet(testDF)
     someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    someRuleSet.addMinMaxRules("MinMax_Cost_manual", col("cost"), Bounds(0.0,12.0))
+    someRuleSet.add(rulesArray)
     val (rulesReport, passed) = someRuleSet.validate()
-    assert(passed == true)
+    rulesReport.show()
+    assert(passed)
+    assert(rulesReport.count() == 10)
   }
 
   test("The input dataframe should have exactly 1 rule failure on MinMaxRule") {
@@ -49,7 +56,7 @@ class ValidationTestSuite extends org.scalatest.FunSuite with SparkSessionFixtur
     val failedResults  = rulesReport.filter(rulesReport("Invalid_Count") > 0).collect()
     assert(failedResults.length == 1)
     assert(failedResults(0)(0) == "MinMax_Cost_max")
-    assert(passed == false)
+    assert(!passed)
   }
 
   test("The DF in the rulesset object is the same as the input test df") {
@@ -89,32 +96,74 @@ class ValidationTestSuite extends org.scalatest.FunSuite with SparkSessionFixtur
     val (groupByValidated, passed) = someRuleSet.validate()
 
     assert(groupBys.length == 1)
-    assert(groupBys(0) == "cost")
-    assert(someRuleSet.isGrouped == true)
-    assert(passed == true)
+    assert(groupBys.head == "cost")
+    assert(someRuleSet.isGrouped)
+    assert(passed)
     assert(groupByValidated.count() == 8)
     assert(groupByValidated.filter(groupByValidated("Invalid_Count") > 0).count() == 0)
     assert(groupByValidated.filter(groupByValidated("Failed") === true).count() == 0)
   }
 
-  test("Validate list of values for numerics.") {
+  test("The group by columns are with rules failing the validation") {
+    // 2 groups so count of the rules should yield (2 minmax rules * 2 columns) * 2 groups in cost (8 rows)
     val testDF = Seq(
       (1, 2, 3),
       (4, 5, 6),
-      (7, 8, 99)
+      (7, 8, 3)
     ).toDF("retail_price", "scan_price", "cost")
-    val rule = Rule("CheckIfCostIsInLOV", col("cost"), Array(3,6,99))
+    val minMaxPriceDefs = Array(
+      MinMaxRuleDef("MinMax_Sku_Price", col("retail_price"), Bounds(0.0, 0.0)),
+      MinMaxRuleDef("MinMax_Scan_Price", col("scan_price"), Bounds(0.0, 29.99))
+    )
+
+    val someRuleSet = RuleSet(testDF, "cost")
+    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
+    val groupBys = someRuleSet.getGroupBys
+    val (groupByValidated, passed) = someRuleSet.validate()
+
+    assert(groupBys.length == 1, "Group by length is not 1")
+    assert(groupBys.head == "cost", "Group by column is not cost")
+    assert(someRuleSet.isGrouped)
+    assert(!passed, "Rule set did not fail.")
+    assert(groupByValidated.count() == 8, "Rule count should be 8")
+    assert(groupByValidated.filter(groupByValidated("Invalid_Count") > 0).count() == 4, "Invalid count is not 4.")
+    assert(groupByValidated.filter(groupByValidated("Failed") === true).count() == 4, "Failed count is not 4.")
+  }
+
+  test("Validate list of values with numeric types, string types and long types.") {
+    val testDF = Seq(
+      ("food_a", 2.51, 3, 111111111111111L),
+      ("food_b", 5.11, 6, 211111111111111L),
+      ("food_c", 8.22, 99, 311111111111111L)
+    ).toDF("product_name", "scan_price", "cost", "id")
+    val numericRules = Array(
+      Rule("CheckIfCostIsInLOV", col("cost"), Array(3,6,99)),
+      Rule("CheckIfScanPriceIsInLOV", col("scan_price"), Array(2.51,5.11,8.22)),
+      Rule("CheckIfIdIsInLOV", col("id"), Array(111111111111111L,211111111111111L,311111111111111L))
+    )
     // Generate the array of Rules from the minmax generator
 
-    val someRuleSet = RuleSet(testDF)
-    someRuleSet.add(rule)
-    assert(rule.ruleType == RuleType.ValidateNumerics)
-//    someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
-//    val (rulesReport, passed) = someRuleSet.validate()
-//    val failedResults  = rulesReport.filter(rulesReport("Invalid_Count") > 0).collect()
-//    assert(failedResults.length == 1)
-//    assert(failedResults(0)(0) == "MinMax_Cost_max")
-//    assert(passed == false)
+    val numericRuleSet = RuleSet(testDF)
+    numericRuleSet.add(numericRules)
+    val (numericValidated, numericPassed) = numericRuleSet.validate()
+    assert(numericRules.map(_.ruleType == RuleType.ValidateNumerics).reduce(_ && _), "Not every value is validate numerics.")
+    assert(numericRules.map(_.boundaries == null).reduce(_ && _), "Boundaries are not null.")
+    assert(numericPassed)
+    assert(numericValidated.filter(numericValidated("Invalid_Count") > 0).count() == 0)
+    assert(numericValidated.filter(numericValidated("Failed") === true).count() == 0)
+
+    val stringRule = Rule("CheckIfProductNameInLOV", col("product_name"), Array("food_a","food_b","food_c"))
+    // Generate the array of Rules from the minmax generator
+
+    val stringRuleSet = RuleSet(testDF)
+    stringRuleSet.add(stringRule)
+    val (stringValidated, stringPassed) = stringRuleSet.validate()
+    assert(stringRule.ruleType == RuleType.ValidateStrings)
+    assert(stringRule.boundaries == null)
+    assert(stringPassed)
+    assert(stringValidated.filter(stringValidated("Invalid_Count") > 0).count() == 0)
+    assert(stringValidated.filter(stringValidated("Failed") === true).count() == 0)
   }
+
 
 }

--- a/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
+++ b/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
@@ -50,10 +50,10 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     assert(rulesReport.count() == 10)
   }
 
-  test("The input rule should have 3 invalid count for MinMax_Scan_Price_Minus_Retail_Price_min for failing complex type.") {
+  test("The input rule should have 1 invalid count for MinMax_Scan_Price_Minus_Retail_Price_min and max for failing complex type.") {
     val expectedDF = Seq(
-      ("MinMax_Retail_Price_Minus_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
-      ("MinMax_Retail_Price_Minus_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),3,true),
+      ("MinMax_Retail_Price_Minus_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),1,true),
+      ("MinMax_Retail_Price_Minus_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),1,true),
       ("MinMax_Scan_Price_Minus_Retail_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
       ("MinMax_Scan_Price_Minus_Retail_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false)
     ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")

--- a/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
+++ b/src/test/scala/com/databricks/labs/validation/ValidatorTestSuite.scala
@@ -57,9 +57,7 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
       ("MinMax_Scan_Price_Minus_Retail_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
       ("MinMax_Scan_Price_Minus_Retail_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false)
     ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
-    val data = Seq()
-    //  2 per rule so 2 MinMax_Sku_Price + 2 MinMax_Scan_Price + 2 MinMax_Cost + 2 MinMax_Cost_Generated
-    // + 2 MinMax_Cost_manual = 10 rules
+
     val testDF = Seq(
       (1, 2, 3),
       (4, 5, 6),
@@ -70,17 +68,10 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
       MinMaxRuleDef("MinMax_Scan_Price_Minus_Retail_Price", col("scan_price")-col("retail_price"), Bounds(0.0, 29.99))
     )
 
-    testDF
-      .withColumn("Retail_Price_Minus_Scan_Price", col("retail_price")-col("scan_price"))
-      .withColumn("Scan_Price_Minus_Retail_Price", col("scan_price")-col("retail_price"))
-      .show()
-
     // Generate the array of Rules from the minmax generator
-
     val someRuleSet = RuleSet(testDF)
     someRuleSet.addMinMaxRules(minMaxPriceDefs: _*)
     val (rulesReport, passed) = someRuleSet.validate()
-    rulesReport.show(false)
     assert(rulesReport.except(expectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(!passed)
     assert(rulesReport.count() == 4)
@@ -91,9 +82,6 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
       ("MinMax_Min_Retail_Price","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
       ("MinMax_Min_Scan_Price","bounds",ValidationValue(null,null,Array(3.0, 29.99),null),1,true)
     ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
-    val data = Seq()
-    //  2 per rule so 2 MinMax_Sku_Price + 2 MinMax_Scan_Price + 2 MinMax_Cost + 2 MinMax_Cost_Generated
-    // + 2 MinMax_Cost_manual = 10 rules
     val testDF = Seq(
       (1, 2, 3),
       (4, 5, 6),
@@ -115,6 +103,14 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
   }
 
   test("The input dataframe should have exactly 1 rule failure on MinMaxRule") {
+    val expectedDF = Seq(
+      ("MinMax_Cost_max","bounds",ValidationValue(null,null,Array(0.0, 12.00),null),1,true),
+      ("MinMax_Cost_min","bounds",ValidationValue(null,null,Array(0.0, 12.00),null),0,false),
+      ("MinMax_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      ("MinMax_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      ("MinMax_Sku_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      ("MinMax_Sku_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false)
+    ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
     val testDF = Seq(
       (1, 2, 3),
       (4, 5, 6),
@@ -132,6 +128,7 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     val (rulesReport, passed) = someRuleSet.validate()
     val failedResults  = rulesReport.filter(rulesReport("Invalid_Count") > 0).collect()
     assert(failedResults.length == 1)
+    assert(rulesReport.except(expectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(failedResults(0)(0) == "MinMax_Cost_max")
     assert(!passed)
   }
@@ -156,6 +153,16 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
   }
 
   test("The group by columns are the correct group by clauses in the validation") {
+    val expectedDF = Seq(
+      (3,"MinMax_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (3,"MinMax_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (3,"MinMax_Sku_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Sku_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (3,"MinMax_Sku_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Sku_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false)
+    ).toDF("cost","Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
     // 2 groups so count of the rules should yield (2 minmax rules * 2 columns) * 2 groups in cost (8 rows)
     val testDF = Seq(
       (1, 2, 3),
@@ -177,11 +184,22 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     assert(someRuleSet.isGrouped)
     assert(passed)
     assert(groupByValidated.count() == 8)
+    assert(groupByValidated.except(expectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(groupByValidated.filter(groupByValidated("Invalid_Count") > 0).count() == 0)
     assert(groupByValidated.filter(groupByValidated("Failed") === true).count() == 0)
   }
 
   test("The group by columns are with rules failing the validation") {
+    val expectedDF = Seq(
+      (3,"MinMax_Sku_Price_max","bounds",ValidationValue(null,null,Array(0.0, 0.0),null),1,true),
+      (6,"MinMax_Sku_Price_max","bounds",ValidationValue(null,null,Array(0.0, 0.0),null),1,true),
+      (3,"MinMax_Sku_Price_min","bounds",ValidationValue(null,null,Array(0.0, 0.0),null),1,true),
+      (6,"MinMax_Sku_Price_min","bounds",ValidationValue(null,null,Array(0.0, 0.0),null),1,true),
+      (3,"MinMax_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Scan_Price_max","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (3,"MinMax_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false),
+      (6,"MinMax_Scan_Price_min","bounds",ValidationValue(null,null,Array(0.0, 29.99),null),0,false)
+    ).toDF("cost","Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
     // 2 groups so count of the rules should yield (2 minmax rules * 2 columns) * 2 groups in cost (8 rows)
     val testDF = Seq(
       (1, 2, 3),
@@ -203,16 +221,24 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     assert(someRuleSet.isGrouped)
     assert(!passed, "Rule set did not fail.")
     assert(groupByValidated.count() == 8, "Rule count should be 8")
+    assert(groupByValidated.except(expectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(groupByValidated.filter(groupByValidated("Invalid_Count") > 0).count() == 4, "Invalid count is not 4.")
     assert(groupByValidated.filter(groupByValidated("Failed") === true).count() == 4, "Failed count is not 4.")
   }
 
   test("Validate list of values with numeric types, string types and long types.") {
+
     val testDF = Seq(
       ("food_a", 2.51, 3, 111111111111111L),
       ("food_b", 5.11, 6, 211111111111111L),
       ("food_c", 8.22, 99, 311111111111111L)
     ).toDF("product_name", "scan_price", "cost", "id")
+
+    val numericLovExpectedDF = Seq(
+      ("CheckIfCostIsInLOV","validNumerics",ValidationValue(null,Array(3,6,99),null,null),0,false),
+      ("CheckIfScanPriceIsInLOV","validNumerics",ValidationValue(null,Array(2.51,5.11,8.22),null,null),0,false),
+      ("CheckIfIdIsInLOV","validNumerics",ValidationValue(null,Array(111111111111111L,211111111111111L,311111111111111L),null,null),0,false)
+    ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
     val numericRules = Array(
       Rule("CheckIfCostIsInLOV", col("cost"), Array(3,6,99)),
       Rule("CheckIfScanPriceIsInLOV", col("scan_price"), Array(2.51,5.11,8.22)),
@@ -226,11 +252,16 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     assert(numericRules.map(_.ruleType == RuleType.ValidateNumerics).reduce(_ && _), "Not every value is validate numerics.")
     assert(numericRules.map(_.boundaries == null).reduce(_ && _), "Boundaries are not null.")
     assert(numericPassed)
+    assert(numericValidated.except(numericLovExpectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(numericValidated.filter(numericValidated("Invalid_Count") > 0).count() == 0)
     assert(numericValidated.filter(numericValidated("Failed") === true).count() == 0)
 
     val stringRule = Rule("CheckIfProductNameInLOV", col("product_name"), Array("food_a","food_b","food_c"))
     // Generate the array of Rules from the minmax generator
+
+    val stringLovExpectedDF = Seq(
+      ("CheckIfProductNameInLOV","validStrings",ValidationValue(null,null,null,Array("food_a", "food_b", "food_c")),0,false)
+    ).toDF("Rule_Name","Rule_Type","Validation_Values","Invalid_Count","Failed")
 
     val stringRuleSet = RuleSet(testDF)
     stringRuleSet.add(stringRule)
@@ -238,6 +269,7 @@ class ValidatorTestSuite extends org.scalatest.FunSuite with SparkSessionFixture
     assert(stringRule.ruleType == RuleType.ValidateStrings)
     assert(stringRule.boundaries == null)
     assert(stringPassed)
+    assert(stringValidated.except(stringLovExpectedDF).count() == 0, "Expected df is not equal to the returned rules report.")
     assert(stringValidated.filter(stringValidated("Invalid_Count") > 0).count() == 0)
     assert(stringValidated.filter(stringValidated("Failed") === true).count() == 0)
   }


### PR DESCRIPTION
added jacoco plugin into sbt
added ruletype enum to make it easier to manage rule types for testing
added entry to contributing.md on how to submit pull requests
added information to readme on how to run tests
altered gitignore to include plugins.sbt which is for jacoco test reports
altered build.sbt to include jacoco test reporting & added scalatest
added 6 tests regarding validation.