### PR TITLE
Fix Failed Status for Bounds in case of Non Aggregate Rule

### DIFF
--- a/src/main/scala/com/databricks/labs/validation/Validator.scala
+++ b/src/main/scala/com/databricks/labs/validation/Validator.scala
@@ -103,9 +103,13 @@ class Validator(ruleSet: RuleSet, detailLvl: Int) extends SparkSessionWrapper {
       rule.ruleType match {
         case "bounds" =>
           val invalid = rule.inputColumn < rule.boundaries.lower || rule.inputColumn > rule.boundaries.upper
-          val failed = when(
-            col(rule.ruleName) < rule.boundaries.lower || col(rule.ruleName) > rule.boundaries.upper, true)
-            .otherwise(false).alias("Failed")
+          val failed = if (rule.isAgg) {
+            when(
+              col(rule.ruleName) < rule.boundaries.lower || col(rule.ruleName) > rule.boundaries.upper, true)
+              .otherwise(false).alias("Failed")
+          } else{
+            when(col(rule.ruleName) > 0,true).otherwise(false).alias("Failed")
+          }
           val first = if (!rule.isAgg) { // Not Agg
             sum(when(invalid, 1).otherwise(0)).alias(rule.ruleName)
           } else { // Is Agg


### PR DESCRIPTION
**Rule("Retail_Price_Validation", col("retail_price"), Bounds(0.0, 6.99))**

Steps to reproduce the issue:

1. Change the example DataFrame to have constant value 6.9 for **retail_price**  column across all rows.
2. Change the Bounds on  **Retail_Price_Validation** Rule as below:

**Rule("Retail_Price_Validation", col("retail_price"), Bounds(5.0, 6.9))**

**Issue** : The Failed status was showing as **True** eventhough the **InvalidCount** is **0**.

Fixed the logic for failed status for such non aggregate rule.
