### PR TITLE
Accept expanded sequence of Rules

### DIFF
--- a/src/main/scala/com/databricks/labs/validation/RuleSet.scala
+++ b/src/main/scala/com/databricks/labs/validation/RuleSet.scala
@@ -93,7 +93,18 @@ class RuleSet extends SparkSessionWrapper {
    * @param rules Array for Rules
    * @return RuleSet
    */
-  def add(rules: Seq[Rule]): this.type = {
+  def add(rules: => Seq[Rule]): this.type = {
+    rules.foreach(rule => _rules.append(rule))
+    this
+  }
+
+  /**
+    * add an expanded sequence of rules
+    *
+    * @param rules expanded Rules sequence
+    * @return RuleSet
+    */
+  def add(rules: Rule*): this.type = {
     rules.foreach(rule => _rules.append(rule))
     this
   }

--- a/src/test/scala/com/databricks/labs/validation/RuleSetTestSuite.scala
+++ b/src/test/scala/com/databricks/labs/validation/RuleSetTestSuite.scala
@@ -166,4 +166,22 @@ class RuleSetTestSuite extends AnyFunSuite with SparkSessionFixture {
 
   }
 
+  test("An expanded sequence of rules can be added to a rule set.") {
+    val testDF = Seq(
+      (1, 2, 3),
+      (4, 5, 6),
+      (7, 8, 9)
+    ).toDF("retail_price", "scan_price", "cost")
+    val validPriceRule = Rule("Valid_Scan_Price_Rule", col("scan_price"), Bounds(0.01, 1000.0))
+    val validCostRule = Rule("Valid_Cost_Rule", col("cost"), Bounds(0.0, 1000.0))
+    val ruleSeq = Seq(validCostRule, validPriceRule)
+    val testRuleSet = RuleSet(testDF).add(ruleSeq: _*)
+
+    // Ensure that the all expanded Rules were added to the RuleSet
+    assert(testRuleSet.getRules.length == 2)
+    assert(testRuleSet.getRules.count(r => Seq("Valid_Scan_Price_Rule", "Valid_Cost_Rule").contains(r.ruleName)) == 2)
+    assert(testRuleSet.getRules.count(_.ruleType == RuleType.ValidateBounds) == 2)
+
+  }
+
 }


### PR DESCRIPTION
Closes #20. This commit adds a new `.add()` method to the RuleSet Class, which accepts an expanded sequence of Rule elements.